### PR TITLE
Redirect to Japanese Code of Conduct

### DIFF
--- a/_includes/links.md
+++ b/_includes/links.md
@@ -2,8 +2,8 @@
 [cc-by-human]: https://creativecommons.org/licenses/by/4.0/
 [cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
 [ci]: http://communityin.org/
-[coc-reporting]: https://docs.carpentries.org/topic_folders/policies/incident-reporting.html
-[coc]: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
+[coc-reporting]: https://carpentries-coc.readthedocs.io/ja/latest/topic_folders/policies/incident-reporting.html
+[coc]: https://carpentries-coc.readthedocs.io/ja/latest/topic_folders/policies/code-of-conduct.html
 [concept-maps]: https://carpentries.github.io/instructor-training/05-memory/
 [contrib-covenant]: https://contributor-covenant.org/
 [contributing]: {{ repo_url }}/blob/{{ source_branch }}/CONTRIBUTING.md


### PR DESCRIPTION
Uses a bilingual translation for excerpts from the Carpentries Handbook.
https://github.com/swcarpentry-ja/carpentries-coc
https://carpentries-coc.readthedocs.io/ja/latest/